### PR TITLE
frontend: Remove webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "stylus-loader": "^3.0.1",
     "url-loader": "^0.5.8",
     "webpack": "^3.8.1",
-    "webpack-dev-server": "2",
     "webpack-eslint-plugin": "^1.2.0"
   },
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,20 +16,6 @@ module.exports = {
     publicPath: '/',
   },
 
-  devServer: {
-    contentBase: path.resolve(__dirname, './frontend'),
-    proxy: {
-      '/images': {
-        target: 'http://localhost:3000/',
-        secure: false
-      },
-      '/api': {
-        target: 'http://localhost:3000/',
-        secure: false
-      },
-    },
-  },
-
   module: {
     loaders: [
       {test: /\.html/, loader: "file-loader?name=[name].[ext]"},


### PR DESCRIPTION
This is a leftover from the early prototype development stage.
It doesn't work that well in our case since there's no directory-based
split between API and static file URLs.